### PR TITLE
Migrate dbt-date to GoDataDriven

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 packages:
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: [">=0.7.0", "<0.10.0"]
   - package: dbt-labs/dbt_utils
     version: [">=1.0.0", "<1.2.0"]


### PR DESCRIPTION
Calogica's [dbt-date](https://github.com/calogica/dbt-date) package is no longer supported. Instead, GoDataDriven's [dbt-date](https://github.com/metaplane/dbt-date) package is now featured on the [dbt Package Hub](https://hub.getdbt.com/godatadriven/dbt_date/latest/). This PR migrates the dependency in this repo.